### PR TITLE
fix: redis non deve essere pubblicato al di fuori del network docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,8 +108,8 @@ services:
     hostname: redis
     volumes:
       - redis-data:/data
-    ports:
-      - "6379:6379"
+    # ports:
+    #   - "6379:6379"
 
   flower:
     image: mher/flower:0.9.7


### PR DESCRIPTION
fix: redis non deve essere pubblicato al di fuori del network dockerdi default.

Potrebbe servire eventualmente per lo sviluppo, ma non va qui.